### PR TITLE
Openssl

### DIFF
--- a/R/mechanisms.R
+++ b/R/mechanisms.R
@@ -31,7 +31,7 @@ mechanism.laplace <- function(fun, x, var.type, rng, sensitivity, epsilon, postl
     # evaluate the noisy statistic
     mechanism.args <- c(as.list(environment()), list(...))
     out <- do.call(fun, getFuncArgs(mechanism.args, fun))
-    out$release <- out$stat + rlap(mu=0, b=(sensitivity / epsilon), size=length(out$stat))
+    out$release <- out$stat + dpNoise(n=length(out$stat), scale=(sensitivity / epsilon), dist='laplace')
     out <- out[names(out) != 'stat']
 
     # post-processing
@@ -79,8 +79,7 @@ mechanism.gaussian <- function(fun, x, var.type, rng, sensitivity, epsilon, delt
     # evaluate the noisy statistic
     mechanism.args <- c(as.list(environment()), list(...))
     out <- do.call(fun, getFuncArgs(mechanism.args, fun))
-    noise <- rnorm(length(out$stat), mean=0, sd=(sensitivity * sqrt(2 * log(1.25 / delta)) / epsilon))
-    out$release <- out$stat + noise
+    out$release <- out$stat + dpNoise(n=length(out$stat), scale=(sensitivity * sqrt(2 * log(1.25 / delta))), dist='gaussian')
     out <- out[names(out) != 'stat']
 
     # post-processing

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -26,15 +26,16 @@ dpUnif <- function(n, seed=NULL) {
 #' @param dist Character specifying the distribution from which to draw the noise
 #' @param seed Integer indicating a seed for R's PNRG, defaults to \code{NULL}
 #'
-#' laplace_noise <- dpNoise(n=1000, scale=1, dist='Laplace')
-#' gaussian_noise <- dpNoise(n=1000, scale=1, dist='Gaussian')
+#' @examples
+#' laplace_noise <- dpNoise(n=1000, scale=1, dist='laplace')
+#' gaussian_noise <- dpNoise(n=1000, scale=1, dist='gaussian')
 #' laplace_noise_repeatable <- dpNoise(n=1, scale=1, dist='Laplace', seed=96845)
 
 dpNoise <- function(n, scale, dist, seed=NULL) {
     u <- dpUnif(n, seed)
-    if (dist == 'Laplace') {
+    if (dist == 'laplace') {
         return(qlap(u, b=scale))
-    } else if (dist == 'Gaussian') {
+    } else if (dist == 'gaussian') {
         return(qnorm(u, sd=scale))
     } else {
         stop(sprintf('Distribution "%s" not understood', dist))


### PR DESCRIPTION
These changes allow drawing secure random variates for the uniform through `openssl::rand_num`. There is now a single noise function that will make draws from the relevant distributions. A seed can be specified to the noise function to get repeatable values, in which case `runif` is used in place of openssl.